### PR TITLE
Bugfix Origin plugin not returning work dir and executable / Replace Launchers property with GetLaunchers Method on LauncherManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Origin plugin did not return working directory and executable name for online queries
 
+### Changed
+- Launchers property replaced with GetLaunchers method on LauncherManager as a property should not be an expensive call. As on first call the plugins are loaded the property can be executing for a bit depending on the system.
+
 
 ## [1.0.5] - 2022-13-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Origin plugin did not return working directory and executable name for online queries
 
 
 ## [1.0.5] - 2022-13-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [1.0.6] - 2022-24-08
 ### Fixed
 - Origin plugin did not return working directory and executable name for online queries
 

--- a/GameLib.Demo/GameLib.Demo.Console/Program.cs
+++ b/GameLib.Demo/GameLib.Demo.Console/Program.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 var launcherManager = new LauncherManager();
 
-foreach (var launcher in launcherManager.Launchers)
+foreach (var launcher in launcherManager.GetLaunchers())
 {
     var name = launcher.Name;
     SetConsoleColor(ConsoleColor.White, ConsoleColor.Red);

--- a/GameLib.Plugin/GameLib.Plugin.Epic/README.md
+++ b/GameLib.Plugin/GameLib.Plugin.Epic/README.md
@@ -24,7 +24,7 @@ using GameLib.Plugin.Epic.Model;
 var launcherManager = new LauncherManager();
 
 // not required to cast here just to add to the documentation
-var launcher = (EpicLauncher?)launcherManager.Launchers
+var launcher = (EpicLauncher?)launcherManager.GetLaunchers()
     .Where(launcher => launcher.Name == "Epic Games")
     // GUID of the class could also be used instead of the name
     //.Where(launcher => launcher.GetType().GUID == new Guid("282B9BB6-54CA-4293-83CF-6F1134CDEEC6"))

--- a/GameLib.Plugin/GameLib.Plugin.Gog/README.md
+++ b/GameLib.Plugin/GameLib.Plugin.Gog/README.md
@@ -23,7 +23,7 @@ using GameLib.Plugin.Gog.Model;
 var launcherManager = new LauncherManager();
 
 // not required to cast here just to add to the documentation
-var launcher = (GogLauncher?)launcherManager.Launchers
+var launcher = (GogLauncher?)launcherManager.GetLaunchers()
     .Where(launcher => launcher.Name == "GOG Galaxy")
     // GUID of the class could also be used instead of the name
     //.Where(launcher => launcher.GetType().GUID == new Guid("54C9D299-107E-4990-894D-9DB402F81CA3"))

--- a/GameLib.Plugin/GameLib.Plugin.Origin/OriginGameFactory.cs
+++ b/GameLib.Plugin/GameLib.Plugin.Origin/OriginGameFactory.cs
@@ -25,8 +25,8 @@ internal static class OriginGameFactory
             return Enumerable.Empty<OriginGame>();
 
         return Directory.GetFiles(localContentPath, "*.mfst", SearchOption.AllDirectories)
-            .AsParallel()
-            .WithCancellation(cancellationToken)
+            //.AsParallel()
+            //.WithCancellation(cancellationToken)
             .Select(manifestFile => DeserializeManifest(manifestFile))
             .Where(game => game is not null)
             .Select(game => { game!.LauncherId = launcherId; return game; })
@@ -78,7 +78,7 @@ internal static class OriginGameFactory
         if (string.IsNullOrEmpty(game.Locale) && contendIds.Count > 0)
             game.Locale = RegistryUtil.GetValue(RegistryHive.LocalMachine, $@"SOFTWARE\Origin Games\{contendIds[0]}", "Locale", string.Empty)!;
 
-        if (string.IsNullOrEmpty(game.ExecutablePath))
+        if (!string.IsNullOrEmpty(game.ExecutablePath))
         {
             game.WorkingDir = Path.GetDirectoryName(game.ExecutablePath) ?? string.Empty;
             game.Executable = Path.GetFileName(game.ExecutablePath);
@@ -211,6 +211,12 @@ internal static class OriginGameFactory
 
                     game.ExecutablePath = string.Empty;
                 }
+            }
+
+            if (!string.IsNullOrEmpty(game.ExecutablePath))
+            {
+                game.WorkingDir = Path.GetDirectoryName(game.ExecutablePath) ?? string.Empty;
+                game.Executable = Path.GetFileName(game.ExecutablePath);
             }
         }
 

--- a/GameLib.Plugin/GameLib.Plugin.Origin/README.md
+++ b/GameLib.Plugin/GameLib.Plugin.Origin/README.md
@@ -23,7 +23,7 @@ using GameLib.Plugin.Origin.Model;
 var launcherManager = new LauncherManager();
 
 // not required to cast here just to add to the documentation
-var launcher = (OriginLauncher?)launcherManager.Launchers
+var launcher = (OriginLauncher?)launcherManager.GetLaunchers()
     .Where(launcher => launcher.Name == "Origin")
     // GUID of the class could also be used instead of the name
     //.Where(launcher => launcher.GetType().GUID == new Guid("54C9D299-107E-4990-894D-9DB402F81CA3"))

--- a/GameLib.Plugin/GameLib.Plugin.Steam/README.md
+++ b/GameLib.Plugin/GameLib.Plugin.Steam/README.md
@@ -22,7 +22,7 @@ using GameLib.Plugin.Steam.Model;
 
 var launcherManager = new LauncherManager();
 
-var launcher = (SteamLauncher?)launcherManager.Launchers
+var launcher = (SteamLauncher?)launcherManager.GetLaunchers()
     .Where(launcher => launcher.Name == "Steam")
     // GUID of the class could also be used instead of the name
     //.Where(launcher => launcher.GetType().GUID == new Guid("5BB973D0-BF3D-4C3E-98B2-41AEFCB1506A"))

--- a/GameLib.Plugin/GameLib.Plugin.Ubisoft/README.md
+++ b/GameLib.Plugin/GameLib.Plugin.Ubisoft/README.md
@@ -23,7 +23,7 @@ using GameLib.Plugin.Ubisoft.Model;
 var launcherManager = new LauncherManager();
 
 // not required to cast here just to add to the documentation
-var launcher = (UbisoftLauncher?)launcherManager.Launchers
+var launcher = (UbisoftLauncher?)launcherManager.GetLaunchers()
     .Where(launcher => launcher.Name == "Ubisoft Connect")
     // GUID of the class could also be used instead of the name
     //.Where(launcher => launcher.GetType().GUID == new Guid("CE276C05-6CD1-4D99-9A5A-2E03ECFB6028"))

--- a/GameLib/LauncherManager.cs
+++ b/GameLib/LauncherManager.cs
@@ -8,17 +8,20 @@ namespace GameLib;
 public class LauncherManager
 {
     [ImportMany(typeof(ILauncher))]
-    public IEnumerable<ILauncher> Launchers { get; init; } = Enumerable.Empty<ILauncher>();
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add read only modifier", Justification = "read only cannot be applied for MEF framework to work")]
+    private IEnumerable<ILauncher>? _launchers;
 
     [Export]
-#pragma warning disable IDE0052 // Remove unread private members
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Field is used in MEF framework")]
     private LauncherOptions LauncherOptions { get; }
-#pragma warning restore IDE0052 // Remove unread private members
 
     public LauncherManager(LauncherOptions? options = null)
     {
         LauncherOptions = options ?? new LauncherOptions();
+    }
 
+    private void LoadPlugins()
+    {
         var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".";
         var catalog = new AggregateCatalog();
         catalog.Catalogs.Add(new DirectoryCatalog(path));
@@ -29,15 +32,24 @@ public class LauncherManager
 
     public void ClearCache()
     {
-        foreach (var launcher in Launchers)
+        foreach (var launcher in GetLaunchers())
         {
             launcher.ClearCache();
         }
     }
 
+    public IEnumerable<ILauncher> GetLaunchers()
+    {
+        if (_launchers is null)
+        {
+            LoadPlugins();
+        }
+        return _launchers!;
+    }
+
     public IEnumerable<IGame> GetGames(CancellationToken cancellationToken = default)
     {
-        return Launchers
+        return GetLaunchers()
             .AsParallel()
             .WithCancellation(cancellationToken)
             .SelectMany(launcher => launcher.GetGames(cancellationToken))

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ using GameLib;
 
 var launcherManager = new LauncherManager(new LauncherOptions() { QueryOnlineData = true });
 
-foreach (var launcher in launcherManager.Launchers)
+foreach (var launcher in launcherManager.GetLaunchers())
 {
     Console.WriteLine($"Launcher name: {launcher.Name}");
     Console.WriteLine("Games:");


### PR DESCRIPTION
## [1.0.6] - 2022-24-08
### Fixed
- Origin plugin did not return working directory and executable name for online queries

### Changed
- Launchers property replaced with GetLaunchers method on LauncherManager as a property should not be an expensive call. As on first call the plugins are loaded the property can be executing for a bit depending on the system.