### PR TITLE
Refresh caused an dead lock in UI applications due to incorrect async…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
+## [1.1.1] - 2022-27-08
+### Fixed
+- Refresh caused an dead lock in UI applications due to incorrect async call
+- Refresh on LauncherManager also returns the Launchers collection so no extra GetLaunchers call need to be made
+
+
 ## [1.1.0] - 2022-27-08
 ### Fixed
 - disable 0649 to avoid compiler warning for MEF variables

--- a/GameLib/LauncherManager.cs
+++ b/GameLib/LauncherManager.cs
@@ -48,24 +48,16 @@ public class LauncherManager
     }
 
     /// <summary>
-    /// Refresh all launcher plugins
+    /// Refresh all launcher plugins and returns the refreshed list
     /// </summary>
-    public void Refresh(CancellationToken cancellationToken = default)
-    {
-        RefreshAsync(cancellationToken).GetAwaiter().GetResult();
-    }
-
-    /// <summary>
-    /// Refresh all launcher plugins in parallel
-    /// </summary>
-    public async Task RefreshAsync(CancellationToken cancellationToken = default)
+    public IEnumerable<ILauncher> Refresh(CancellationToken cancellationToken = default)
     {
         LoadPlugins();
-        var tasks = (_launchers!
-            .Select(l => Task.Run(() => l.Refresh(cancellationToken))))
+        return _launchers!
+            .AsParallel()
+            .WithCancellation(cancellationToken)
+            .Select(l => { l.Refresh(cancellationToken); return l; })
             .ToList();
-
-        await Task.WhenAll(tasks);
     }
 
     /// <summary>


### PR DESCRIPTION
## [1.1.1] - 2022-27-08
### Fixed
- Refresh caused an dead lock in UI applications due to incorrect async call
- Refresh on LauncherManager also returns the Launchers collection so no extra GetLaunchers call need to be made