### PR TITLE
Fix ArgumentException when GOG game has no EXE path specified

### DIFF
--- a/GameLib.Plugin/GameLib.Plugin.Gog/GogGameFactory.cs
+++ b/GameLib.Plugin/GameLib.Plugin.Gog/GogGameFactory.cs
@@ -99,7 +99,7 @@ internal static class GogGameFactory
             return null;
         }
 
-        game.InstallDir = Path.GetDirectoryName(game.Executable) ?? string.Empty;
+        game.InstallDir = string.IsNullOrEmpty(game.Executable) ? string.Empty : Path.GetDirectoryName(game.Executable) ?? string.Empty;
         game.LaunchString = $"\"{launcher.Executable}\" /command=runGame /gameId={game.Id}";
         if (!string.IsNullOrEmpty(game.WorkingDir))
         {


### PR DESCRIPTION
I've encountered a case when GOG game registry entry (**Cyberpank 2077 - EP1**) has no executable path specified, as it's not a base game. The plugin uses `string.Empty` as default values when some registry value is not specified, but `string.Empty` is not a valid argument for `Path.GetDirectoryName` and will lead to unhandled `ArgumentException` being thrown by `NormalizePath` method.